### PR TITLE
Unable to run after issue - Fix

### DIFF
--- a/Exomia.Network/ServerBase.cs
+++ b/Exomia.Network/ServerBase.cs
@@ -161,13 +161,13 @@ namespace Exomia.Network
         public bool Run(int port)
         {
             if (_isRunning) { return true; }
-            _isRunning = true;
             _port      = port;
 
             if (OnRun(port, out _listener))
             {
                 _state = RECEIVE_FLAG | SEND_FLAG;
                 ListenAsync();
+                _isRunning = true;
                 return true;
             }
             return false;


### PR DESCRIPTION

Wenn der start des Listeners fehler wirft, dann bist hast du die Variable _isRunning schon als wahr gesetzt und rennst by einem erneuten run() drüber weg als würder der Server laufen

```csharp
//Task
// _isRunning = false;
if(!Run(-8080)) {
         // CodeLens
        //  public bool Run(int port)  {
        //            if (_isRunning) { return true; }  // _isRunning = false;
        //             _isRunning = true; // _isRunning = true;
        //             _port      = port; // _isRunning = true;
        // 
        //             if (OnRun(port, out _listener))  { // _isRunning = true; | Failed onPort
        //                        _state = RECEIVE_FLAG | SEND_FLAG;
        //                        ListenAsync();
        //                       return true;
        //             }
        //             return false;  // _isRunning = true; 
        //  }
        // _isRunning = true;  
        Run(8080);
        // CodeLens
        //  public bool Run(int port)  {
        //            if (_isRunning) { // _isRunning = true;
        //                      return true; // _isRunning = true; | Jump out bc __isRunning== true
        //            }
        //             _isRunning = true; 
        //             _port      = port;
        // 
        //             if (OnRun(port, out _listener))  {
        //                        _state = RECEIVE_FLAG | SEND_FLAG;
        //                        ListenAsync();
        //                       return true;
        //             }
        //             return false;
        //  }
}

```

**Fix**
```charp
public bool Run(int port)  {
         if (_isRunning) {
                  return true;
         }
         _port      = port;

          if (OnRun(port, out _listener))  {
                  _state = RECEIVE_FLAG | SEND_FLAG;
                  ListenAsync();
                   _isRunning = true; 
                   return true;
          }
          return false;
}
```
